### PR TITLE
Clean up example and get rid of code deprecation

### DIFF
--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/NaluSimpleApplication.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/NaluSimpleApplication.java
@@ -32,12 +32,7 @@ import com.github.nalukit.nalu.plugin.elemental2.client.DefaultElemental2Logger;
  * <p>Please keep in mind, the services are simulated inside the client (because this is not part of the
  * framework). You can use any technique to call the server!</p>
  */
-// use this annotation definition, to run the example using a hash token
-//@Application(loader = NaluSimpleApplicationLoader.class,
-//             startRoute = "/application/search",
-//             context = NaluSimpleApplicationContext.class,
-//             routeError = "/application/search")
-// use this annotation definition, to run the example using a hashless url
+// to run the example with hashless url, use Application annotation attribute `useHash = false`
 @Application(loader = NaluSimpleApplicationLoader.class,
              startRoute = "/application/search",
              context = NaluSimpleApplicationContext.class)

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/data/service/PersonService.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/data/service/PersonService.java
@@ -42,7 +42,7 @@ public class PersonService {
 
   private PersonService() {
     if (persons == null) {
-      persons = new HashMap<Long, Person>();
+      persons = new HashMap<>();
       initList();
     }
   }
@@ -59,27 +59,27 @@ public class PersonService {
                                     "Evergreen Terrace",
                                     "7 42",
                                     "Springfield");
-    persons.put(new Long(1),
+    persons.put(1L,
                 new Person(1,
                            "Simpsons",
                            "Homer",
                            address01));
-    persons.put(new Long(2),
+    persons.put(2L,
                 new Person(2,
                            "Simpsons",
                            "Marge",
                            address01));
-    persons.put(new Long(3),
+    persons.put(3L,
                 new Person(3,
                            "Simpsons",
                            "Bart",
                            address01));
-    persons.put(new Long(4),
+    persons.put(4L,
                 new Person(4,
                            "Simpsons",
                            "Maggie",
                            address01));
-    persons.put(new Long(5),
+    persons.put(5L,
                 new Person(5,
                            "Simpsons",
                            "Lisa",
@@ -88,22 +88,22 @@ public class PersonService {
                                     "Blumenweg Nr. 13",
                                     "",
                                     "Entenhausen");
-    persons.put(new Long(6),
+    persons.put(6L,
                 new Person(6,
                            "Duck",
                            "Donald",
                            address02));
-    persons.put(new Long(7),
+    persons.put(7L,
                 new Person(7,
                            "Duck",
                            "Trick",
                            address02));
-    persons.put(new Long(8),
+    persons.put(8L,
                 new Person(8,
                            "Duck",
                            "Tick",
                            address02));
-    persons.put(new Long(9),
+    persons.put(9L,
                 new Person(9,
                            "Duck",
                            "Tack",
@@ -112,7 +112,7 @@ public class PersonService {
                                     "Am Goldberg Nr. 1",
                                     "",
                                     "Entenhausen");
-    persons.put(new Long(10),
+    persons.put(10L,
                 new Person(10,
                            "Duck",
                            "Dagobert",
@@ -121,15 +121,15 @@ public class PersonService {
 
   public Person get(long id)
       throws PersonNotFoundException {
-    if (persons.containsKey(new Long(id))) {
+    if (persons.containsKey(id)) {
       return persons.get(id);
     } else {
-      throw new PersonNotFoundException("no data found for ID >>" + Long.toString(id) + "<<");
+      throw new PersonNotFoundException("no data found for ID >>" + id + "<<");
     }
   }
 
   public List<Person> getAll() {
-    List<Person> list = new ArrayList<Person>();
+    List<Person> list = new ArrayList<>();
     Iterator<Long> iterator = persons.keySet()
                                      .iterator();
     while (iterator.hasNext()) {
@@ -139,7 +139,7 @@ public class PersonService {
   }
 
   public List<Person> get(PersonSearch search) {
-    List<Person> list = new ArrayList<Person>();
+    List<Person> list = new ArrayList<>();
     if ((search.getName() != null &&
          search.getName()
                .length() != 0) ||
@@ -205,16 +205,16 @@ public class PersonService {
     }
     maxKey++;
     person.setId(maxKey);
-    persons.put(new Long(maxKey),
+    persons.put(maxKey,
                 person);
   }
 
   public void update(Person person)
       throws PersonException {
-    Person value = persons.get(new Long(person.getId()));
+    Person value = persons.get(person.getId());
     if (value != null) {
-      persons.remove(new Long(person.getId()));
-      persons.put(new Long(person.getId()),
+      persons.remove(person.getId());
+      persons.put(person.getId(),
                   person);
     }
   }

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/event/StatusChangeEvent.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/event/StatusChangeEvent.java
@@ -5,7 +5,7 @@ import org.gwtproject.event.shared.Event;
 public class StatusChangeEvent
     extends Event<StatusChangeEvent.StatusChangeHandler> {
 
-  public static Type<StatusChangeEvent.StatusChangeHandler> TYPE = new Type<StatusChangeEvent.StatusChangeHandler>();
+  public static Type<StatusChangeEvent.StatusChangeHandler> TYPE = new Type<>();
 
   private String status;
 

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/content/detail/DetailComponent.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/content/detail/DetailComponent.java
@@ -62,16 +62,12 @@ public class DetailComponent
                                          .add(button().css("button")
                                                       .textContent("Save")
                                                       .on(click,
-                                                          event -> {
-                                                            getController().doUpdate();
-                                                          }))
+                                                          event -> getController().doUpdate()))
                                          .add(button().css("button")
                                                       .textContent("Revert")
                                                       .on(click,
-                                                          event -> {
-                                                            getController().doRevert();
-                                                          }))))
-                     .get());
+                                                          event -> getController().doRevert()))))
+                     .element());
   }
 
   @Override

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/content/list/ListComponent.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/content/list/ListComponent.java
@@ -46,7 +46,7 @@ public class ListComponent
     initElement(this.container = div().add(div().style("width: 100%"))
                                       .add(div().css("headline")
                                                 .textContent("Search Results"))
-                                      .asElement());
+                                      .element());
   }
 
   public void setName(String name) {
@@ -85,7 +85,7 @@ public class ListComponent
                                               .textContent("Zip"))
                                      .add(th().css("resultTableHeader")
                                               .textContent("City")))
-                         .get();
+                         .element();
 
     for (Person person : result) {
       resultTable.appendChild(this.createTableDataRow(person));
@@ -105,7 +105,7 @@ public class ListComponent
                                            .getZip()))
                .add(td().textContent(person.getAddress()
                                            .getCity()))
-               .get();
+               .element();
   }
 
   private void update(Person object) {

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/content/list/ListController.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/content/list/ListController.java
@@ -56,7 +56,7 @@ public class ListController
     } else if (result.size() == 1) {
       this.eventBus.fireEvent(new StatusChangeEvent("Found one person"));
     } else {
-      this.eventBus.fireEvent(new StatusChangeEvent("Found " + Integer.toString(result.size()) + " persons"));
+      this.eventBus.fireEvent(new StatusChangeEvent("Found " + result.size() + " persons"));
     }
   }
 

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/content/search/SearchComponent.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/content/search/SearchComponent.java
@@ -56,7 +56,7 @@ public class SearchComponent
                                                             searchName.setText("");
                                                             searchCity.setText("");
                                                           }))))
-                     .get());
+                     .element());
   }
 
   @Override

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/footer/FooterComponent.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/footer/FooterComponent.java
@@ -45,7 +45,7 @@ public class FooterComponent
                                                         .textContent("GWT Basic training")))
                                   .add(div().css("shellFooterRight")
                                             .add(status = label().css("shellFooterStatus"))))
-                        .get());
+                        .element());
   }
 
   @Override

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/header/HeaderComponent.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/header/HeaderComponent.java
@@ -34,7 +34,7 @@ public class HeaderComponent
   public void render() {
     initElement(header().css("shellHeader")
                         .add(img("/media/images/Gwt-logo.png").css("shellHeaderImage"))
-                        .get());
+                        .element());
   }
 
 }

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/navigation/NavigationComponent.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/navigation/NavigationComponent.java
@@ -41,7 +41,7 @@ public class NavigationComponent
                                   .textContent("List")
                                   .on(click,
                                       event -> showList()))
-                     .get());
+                     .element());
   }
 
   private void showSearch() {

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/shell/ApplicationShell.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/application/shell/ApplicationShell.java
@@ -18,7 +18,6 @@
 package com.github.nalukit.example.nalu.simpleapplication.client.ui.application.shell;
 
 import com.github.nalukit.example.nalu.simpleapplication.client.NaluSimpleApplicationContext;
-import com.github.nalukit.nalu.client.Nalu;
 import com.github.nalukit.nalu.client.component.AbstractShell;
 import com.github.nalukit.nalu.client.component.annotation.Shell;
 import elemental2.dom.CSSProperties;
@@ -76,7 +75,7 @@ public class ApplicationShell
                       .add(div().css("shellContent")
                                 .attr("id",
                                       "content"))
-                      .get();
+                      .element();
 
     return this.shell;
   }
@@ -85,14 +84,14 @@ public class ApplicationShell
     return header().css("shellHeader")
                    .attr("id",
                          "header")
-                   .get();
+                   .element();
   }
 
   private Element createSouth() {
     return footer().css("shellFooter")
                    .attr("id",
                          "footer")
-                   .get();
+                   .element();
   }
 
 }

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/error/content/error/ErrorComponent.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/error/content/error/ErrorComponent.java
@@ -47,19 +47,19 @@ public class ErrorComponent
   public void render() {
     this.errorType = Elements.div()
                              .css("headline")
-                             .get();
+                             .element();
     this.errorRoute = Elements.div()
                               .css("text")
-                              .get();
+                              .element();
     this.errorMessage = Elements.div()
                                 .css("text")
-                                .get();
+                                .element();
 
     this.okButton = Elements.button()
                             .add("OK")
                             .css("button")
                             .on(click, e -> getController().doClickOkButton())
-                            .get();
+                            .element();
 
     initElement(div().add(div().style("width: 100%; text-align: center; padding: 24px;")
                                .add(div().add(this.errorType))
@@ -74,7 +74,7 @@ public class ErrorComponent
                                .add(Elements.div()
                                             .add(this.errorRoute))
                                .add(Elements.div()
-                                            .add(this.okButton))).get());
+                                            .add(this.okButton))).element());
   }
 
   @Override

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/error/content/error/IErrorComponent.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/error/content/error/IErrorComponent.java
@@ -19,7 +19,6 @@ package com.github.nalukit.example.nalu.simpleapplication.client.ui.error.conten
 
 import com.github.nalukit.nalu.client.component.IsComponent;
 import com.github.nalukit.nalu.client.event.model.ErrorInfo;
-import com.google.gwt.user.client.ui.Widget;
 import elemental2.dom.HTMLElement;
 
 public interface IErrorComponent

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/error/shell/ErrorShell.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/ui/error/shell/ErrorShell.java
@@ -52,7 +52,7 @@ public class ErrorShell
     this.shell = div().css("shell")
                       .add(div().attr("id",
                                       "content"))
-                      .get();
+                      .element();
 
     document.body.appendChild(this.shell);
   }

--- a/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/widgets/TextField.java
+++ b/NaluElementoSimpleApplication/src/main/java/com/github/nalukit/example/nalu/simpleapplication/client/widgets/TextField.java
@@ -55,19 +55,19 @@ public class TextField
                           "textFieldTwoRow")
                      .add(label = div().css("textFieldLabel",
                                             "visible")
-                                       .get())
+                                       .element())
                      .add(div().css("textFieldDivElement")
                                .add(textBox = input(InputType.text).css("textFieldTextBox")
                                                                    .on(focus,
                                                                        event -> textBox.classList.add("yellow"))
                                                                    .on(blur,
                                                                        event -> textBox.classList.remove("yellow"))
-                                                                   .get()))
-                     .get();
+                                                                   .element()))
+                     .element();
   }
 
   public String getLabel() {
-    return label.innerHTML.toString();
+    return label.innerHTML;
   }
 
   public void setLabel(String label) {


### PR DESCRIPTION
Replaced deprecated `ElementBuilder` methods `get()` and `asElement()` with `element()`.
Additionally, the following actions were performed to increase code readability:
* removed redundant to-string conversion,
* removed dead code and misleading comment (hash vs hashless description was mixed up),
* explicit type replaced with diamond operator,
* removed unnecessary boxing,
* removed unused imports.